### PR TITLE
Fix fasttext binary vectors url and support to torch>=1.0.1

### DIFF
--- a/deepmatcher/batch.py
+++ b/deepmatcher/batch.py
@@ -48,7 +48,8 @@ class AttrTensor(AttrTensor_):
             if 'word_probs' in train_info.metadata:
                 raw_word_probs = train_info.metadata['word_probs'][name]
                 word_probs = torch.Tensor(
-                    [[raw_word_probs[w] for w in b] for b in data.data])
+                    # [[raw_word_probs[w] for w in b] for b in data.data])
+                    [[raw_word_probs[w] for w in b] for b in data.data.tolist()])
                 if data.is_cuda:
                     word_probs = word_probs.cuda()
             pc = None

--- a/deepmatcher/data/dataset.py
+++ b/deepmatcher/data/dataset.py
@@ -24,7 +24,6 @@ from .iterator import MatchingIterator
 
 logger = logging.getLogger(__name__)
 
-
 def split(table,
           path,
           train_prefix,
@@ -203,7 +202,7 @@ class MatchingDataset(data.Dataset):
         self.label_field = self.column_naming['label']
         self.id_field = self.column_naming['id']
 
-    def compute_metadata(self, pca=False):
+    def compute_metadata(self, pca=False, device=None):
         r"""Computes metadata about the dataset.
 
         Computes the following metadata about the dataset:
@@ -220,12 +219,20 @@ class MatchingDataset(data.Dataset):
 
         Arguments:
             pca (bool): Whether to compute the ``pc`` metadata.
+            device (str or torch.device): The device type on which compute metadata of the model. 
+                Set to 'cpu' to use CPU only, even if GPU is available. 
+                If None, will use first available GPU, or use CPU if no GPUs are available. 
+                Defaults to None.
+                This is a keyword only param.
         """
+        if device is None:
+            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+        
         self.metadata = {}
 
         # Create an iterator over the entire dataset.
         train_iter = MatchingIterator(
-            self, self, train=False, batch_size=1024, device=-1, sort_in_buckets=False)
+            self, self, train=False, batch_size=1024, device=device, sort_in_buckets=False)
         counter = defaultdict(Counter)
 
         # For each attribute, find the number of times each word id occurs in the dataset.
@@ -233,7 +240,7 @@ class MatchingDataset(data.Dataset):
         for batch in pyprind.prog_bar(train_iter, title='\nBuilding vocabulary'):
             for name in self.all_text_fields:
                 attr_input = getattr(batch, name)
-                counter[name].update(attr_input.data.data.view(-1))
+                counter[name].update(attr_input.data.data.view(-1).tolist())
 
         word_probs = {}
         totals = {}
@@ -270,7 +277,7 @@ class MatchingDataset(data.Dataset):
 
         # Create an iterator over the entire dataset.
         train_iter = MatchingIterator(
-            self, self, train=False, batch_size=1024, device=-1, sort_in_buckets=False)
+            self, self, train=False, batch_size=1024, device=device, sort_in_buckets=False)
         attr_embeddings = defaultdict(list)
 
         # Run the constructed neural network to compute weighted sequence embeddings
@@ -524,11 +531,19 @@ class MatchingDataset(data.Dataset):
             filter_pred (callable or None): Use only examples for which
                 filter_pred(example) is True, or use all examples if None.
                 Default is None. This is a keyword-only parameter.
+            device (str or torch.device): The device type on which compute metadata of the model. 
+                Set to 'cpu' to use CPU only, even if GPU is available. 
+                If None, will use first available GPU, or use CPU if no GPUs are available. 
+                Defaults to None.
+                This is a keyword only param.
 
         Returns:
             Tuple[MatchingDataset]: Datasets for (train, validation, and test) splits in
                 that order, if provided.
         """
+        device = kwargs.pop('device', None)
+        if device is None:
+            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
         fields_dict = dict(fields)
         state_args = {'train_pca': train_pca}
@@ -578,7 +593,7 @@ class MatchingDataset(data.Dataset):
             logger.info('Vocab construction time: {}s'.format(after_vocab - after_load))
 
             if train:
-                datasets[0].compute_metadata(train_pca)
+                datasets[0].compute_metadata(train_pca, device)
             after_metadata = timer()
             logger.info(
                 'Metadata computation time: {}s'.format(after_metadata - after_vocab))

--- a/deepmatcher/data/iterator.py
+++ b/deepmatcher/data/iterator.py
@@ -8,7 +8,6 @@ from ..batch import MatchingBatch
 
 logger = logging.getLogger(__name__)
 
-
 class MatchingIterator(data.BucketIterator):
 
     def __init__(self,

--- a/deepmatcher/data/process.py
+++ b/deepmatcher/data/process.py
@@ -103,7 +103,8 @@ def process(path,
             left_prefix='left_',
             right_prefix='right_',
             use_magellan_convention=False,
-            pca=True):
+            pca=True,
+            **kwargs):
     """Creates dataset objects for multiple splits of a dataset.
 
     This involves the following steps (if data cannot be retrieved from the cache):
@@ -174,11 +175,20 @@ def process(path,
             Specifically, set them to be '_id', 'ltable_', and 'rtable_' respectively.
         pca (bool): Whether to compute PCA for each attribute (needed for SIF model).
             Defaults to False.
+        device (str or torch.device): The device type on which compute metadata of the model. 
+            Set to 'cpu' to use CPU only, even if GPU is available. 
+            If None, will use first available GPU, or use CPU if no GPUs are available. 
+            Defaults to None.
+            This is a keyword only param.
 
     Returns:
         Tuple[MatchingDataset]: Datasets for (train, validation, and test) splits in that
             order, if provided, or dataset for unlabeled, if provided.
     """
+    device = kwargs.pop('device', None)
+    if device is None:
+        device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
     if unlabeled is not None:
         raise ValueError('Parameter "unlabeled" has been deprecated, use '
                          '"deepmatcher.data.process_unlabeled" instead.')
@@ -217,7 +227,8 @@ def process(path,
         cache,
         check_cached_data,
         auto_rebuild_cache,
-        train_pca=pca)
+        train_pca=pca,
+        **kwargs)
 
     # Save additional information to train dataset.
     datasets[0].ignore_columns = ignore_columns

--- a/deepmatcher/models/core.py
+++ b/deepmatcher/models/core.py
@@ -15,7 +15,6 @@ from ..utils import Bunch, tally_parameters
 
 logger = logging.getLogger('deepmatcher.core')
 
-
 class MatchingModel(nn.Module):
     r"""A neural network model for entity matching.
 
@@ -158,10 +157,11 @@ class MatchingModel(nn.Module):
                 Mini-batch size for SGD. For details on what this is
                 `see this video <https://www.coursera.org/learn/machine-learning/lecture/9zJUs/mini-batch-gradient-descent>`__.
                 Defaults to 32. This is a keyword only param.
-            device (int):
-                The device index of the GPU on which to train the model. Set to -1 to use
-                CPU only, even if GPU is available. If None, will use first available GPU,
-                or use CPU if no GPUs are available. Defaults to None.
+            device (str or torch.device):
+                The device type on which compute metadata of the model. 
+                Set to 'cpu' to use CPU only, even if GPU is available. 
+                If None, will use first available GPU, or use CPU if no GPUs are available. 
+                Defaults to None.
                 This is a keyword only param.
             progress_style (string):
                 Sets the progress update style. One of 'bar' or 'log'. If 'bar', uses a
@@ -195,10 +195,11 @@ class MatchingModel(nn.Module):
                 Mini-batch size for SGD. For details on what this is
                 `see this video <https://www.coursera.org/learn/machine-learning/lecture/9zJUs/mini-batch-gradient-descent>`__.
                 Defaults to 32. This is a keyword only param.
-            device (int):
-                The device index of the GPU on which to train the model. Set to -1 to use
-                CPU only, even if GPU is available. If None, will use first available GPU,
-                or use CPU if no GPUs are available. Defaults to None.
+            device (str or torch.device):
+                The device type on which compute metadata of the model. 
+                Set to 'cpu' to use CPU only, even if GPU is available. 
+                If None, will use first available GPU, or use CPU if no GPUs are available. 
+                Defaults to None.
                 This is a keyword only param.
             progress_style (string):
                 Sets the progress update style. One of 'bar' or 'log'. If 'bar', uses a
@@ -235,10 +236,11 @@ class MatchingModel(nn.Module):
                 Mini-batch size for SGD. For details on what this is
                 `see this video <https://www.coursera.org/learn/machine-learning/lecture/9zJUs/mini-batch-gradient-descent>`__.
                 Defaults to 32. This is a keyword only param.
-            device (int):
-                The device index of the GPU on which to train the model. Set to -1 to use
-                CPU only, even if GPU is available. If None, will use first available GPU,
-                or use CPU if no GPUs are available. Defaults to None.
+            device (str or torch.device):
+                The device type on which compute metadata of the model. 
+                Set to 'cpu' to use CPU only, even if GPU is available. 
+                If None, will use first available GPU, or use CPU if no GPUs are available. 
+                Defaults to None.
                 This is a keyword only param.
             progress_style (string):
                 Sets the progress update style. One of 'bar' or 'log'. If 'bar', uses a
@@ -263,7 +265,7 @@ class MatchingModel(nn.Module):
         """
         return Runner.predict(self, *args, **kwargs)
 
-    def initialize(self, train_dataset, init_batch=None):
+    def initialize(self, train_dataset, init_batch=None, **kwargs):
         r"""Initialize (not lazily) the matching model given the actual training data.
 
         Instantiates all sub-components and their trainable parameters.
@@ -274,7 +276,16 @@ class MatchingModel(nn.Module):
             init_batch (:class:`~deepmatcher.batch.MatchingBatch`):
                 A batch of data to forward propagate through the model. If None, a batch
                 is drawn from the training dataset.
+            device (str or torch.device):
+                The device type on which compute metadata of the model. 
+                Set to 'cpu' to use CPU only, even if GPU is available. 
+                If None, will use first available GPU, or use CPU if no GPUs are available. 
+                Defaults to None.
+                This is a keyword only param.
         """
+        device = kwargs.pop('device', None)
+        if device is None:
+            device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
 
         if self._initialized:
             return
@@ -344,6 +355,9 @@ class MatchingModel(nn.Module):
 
         self._reset_embeddings(train_dataset.vocabs)
 
+        if not isinstance(device, torch.device):
+            device = torch.device(device)
+
         # Instantiate all components using a small batch from training set.
         if not init_batch:
             run_iter = MatchingIterator(
@@ -351,9 +365,14 @@ class MatchingModel(nn.Module):
                 train_dataset,
                 train=False,
                 batch_size=4,
-                device=-1,
+                device=device,
                 sort_in_buckets=False)
             init_batch = next(run_iter.__iter__())
+            
+        if (device == 'cuda' or device.type == 'cuda') and torch.cuda.is_available():
+            self.cuda()
+        else:
+            raise ValueError('No GPU available')
         self.forward(init_batch)
 
         # Keep this init_batch for future initializations.
@@ -460,7 +479,7 @@ class MatchingModel(nn.Module):
                 state[k] = getattr(self, k)
         torch.save(state, path)
 
-    def load_state(self, path):
+    def load_state(self, path, device=None):
         r"""Load the model state from a file in a certain path.
 
         Args:
@@ -480,7 +499,7 @@ class MatchingModel(nn.Module):
             train_info.metadata = train_info.orig_metadata
             MatchingDataset.finalize_metadata(train_info)
 
-            self.initialize(train_info, self.state_meta.init_batch)
+            self.initialize(train_info, self.state_meta.init_batch, device)
 
         self.load_state_dict(state['model'])
 

--- a/deepmatcher/models/modules.py
+++ b/deepmatcher/models/modules.py
@@ -860,7 +860,7 @@ class Bypass(LazyModule):
                 res *= math.sqrt(0.5)
             return res
         elif self.style == 'highway':
-            transform_gate = F.sigmoid(self.highway_gate(raw) + self.highway_bias)
+            transform_gate = torch.sigmoid(self.highway_gate(raw) + self.highway_bias)
             carry_gate = 1 - transform_gate
             return transform_gate * transformed + carry_gate * adjusted_raw
 

--- a/deepmatcher/optim.py
+++ b/deepmatcher/optim.py
@@ -4,7 +4,8 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 from torch.autograd import Variable
-from torch.nn.utils import clip_grad_norm
+# from torch.nn.utils import clip_grad_norm
+from torch.nn.utils import clip_grad_norm_ 
 
 logger = logging.getLogger('deepmatcher.optim')
 
@@ -143,7 +144,8 @@ class Optimizer(object):
         self._step += 1
 
         if self.max_grad_norm:
-            clip_grad_norm(self.params, self.max_grad_norm)
+            # clip_grad_norm(self.params, self.max_grad_norm)
+            clip_grad_norm_(self.params, self.max_grad_norm)
         self.base_optimizer.step()
 
     def update_learning_rate(self, acc, epoch):

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     packages=['deepmatcher', 'deepmatcher.data', 'deepmatcher.models'],
     python_requires='>=3.5',
     install_requires=[
-        'torch==0.3.1', 'tqdm', 'pyprind', 'six', 'Cython', 'torchtext', 'nltk>=3.2.5',
-        'fasttextmirror', 'pandas'
+        'torch>=1.0.1', 'tqdm', 'pyprind', 'six', 'Cython', 'torchtext', 'nltk>=3.2.5',
+        'pandas', 'requests', 'fasttextmirror'
     ])


### PR DESCRIPTION
I've updated the download urls for the fasttext binaries as they seem to be down: i've used the ones from fasttext official page.
I've made possible to use torch>=1.0.1 thanks to @kkonevets