### PR TITLE
Add sklearn into requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'torch==0.3.1', 'tqdm', 'pyprind', 'six', 'Cython', 'torchtext', 'nltk>=3.2.5',
-        'fasttextmirror', 'pandas'
+        'fasttextmirror', 'pandas', 'scikit-learn'
     ])


### PR DESCRIPTION
I noticed the file deepmatcher/data/dataset.py use sklearn at line14.
`from sklearn.decomposition import TruncatedSVD`
However, sklearn is not included in the requirements in setup.py.