### PR TITLE
change to original fasttext package

### DIFF
--- a/deepmatcher/data/field.py
+++ b/deepmatcher/data/field.py
@@ -6,7 +6,7 @@ import zipfile
 import nltk
 import six
 
-import fastText
+import fasttext
 import torch
 from torchtext import data, vocab
 from torchtext.utils import download_from_url

--- a/deepmatcher/data/field.py
+++ b/deepmatcher/data/field.py
@@ -77,7 +77,7 @@ class FastTextBinary(vocab.Vectors):
         if not os.path.isfile(path):
             raise RuntimeError('no vectors found at {}'.format(path))
 
-        self.model = fastText.load_model(path)
+        self.model = fasttext.load_model(path)
         self.dim = len(self['a'])
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'torch>=1.0', 'tqdm', 'pyprind', 'six', 'Cython', 'torchtext', 'nltk>=3.2.5',
-        'fasttextmirror', 'pandas', 'dill', 'scikit-learn'
+        'fasttext', 'pandas', 'dill', 'scikit-learn'
     ])


### PR DESCRIPTION
The official "fasttext"package has been very well maintained. This "fasttextmirror" package could cause installation issues on Windows. Thanks!